### PR TITLE
Fixing critical vulnerability in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   },
   "devDependencies": {
     "@types/node": "10.17.27",
-    "aws-cdk": "2.3.0",
+    "aws-cdk": "^2.3.0",
     "ts-node": "^9.0.0",
     "typescript": "~3.9.7",
     "@aws-sdk/client-ec2": "3.45.0",
     "esbuild": "0.14.10"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.3.0",
+    "aws-cdk-lib": "^2.3.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.16"
   }


### PR DESCRIPTION
The package aws-cdk in version 2.3.0 depends on package vm2 < 3.9.6 which is affected by a critical vulnerability that expose to Sandbox bypass https://github.com/advisories/GHSA-6pw2-5hjv-9pf7