### PR TITLE
feat(eip): add option for adding elastic ip

### DIFF
--- a/server-hosting/config.sample.ts
+++ b/server-hosting/config.sample.ts
@@ -12,6 +12,8 @@ export const Config = {
      restartApi: true,
      // Set to true if you want to use Satisfactory Experimental
      useExperimentalBuild: false,
+     // Set to true if you want to assign an elastic IP address (EIP)
+     useEip: false,
 
      // optional parameters
 

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -85,6 +85,16 @@ export class ServerHostingStack extends Stack {
       securityGroup,
     })
 
+    if (Config.useEip) {
+      const eip = new ec2.CfnEIP(this, 'IP')
+
+      // Elastic IP reference
+      new ec2.CfnEIPAssociation(this, 'Association', {
+        eip: eip.ref,
+        instanceId: server.instanceId,
+      })
+    }
+
     // Add Base SSM Permissions, so we can use AWS Session Manager to connect to our server, rather than external SSH.
     server.role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
 


### PR DESCRIPTION
This change adds a config option for adding an elastic IP and association with the server. By default, this option is set to false.