### PR TITLE
Updated dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-hosting",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "server-hosting": "server-hosting/server-hosting.js"
   },
@@ -10,16 +10,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/node": "10.17.27",
-    "aws-cdk": "2.3.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~3.9.7",
-    "@aws-sdk/client-ec2": "3.45.0",
-    "esbuild": "0.14.10"
+    "@types/node": "^20.5.0",
+    "aws-cdk": "^2.154.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4",
+    "@aws-sdk/client-ec2": "^3.636.0",
+    "esbuild": "^0.23.1"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.3.0",
-    "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "aws-cdk-lib": "^2.154.0",
+    "constructs": "^10.3.0",
+    "source-map-support": "^0.5.21"
   }
 }


### PR DESCRIPTION
Dependencies have become stale after 3 years of no updates.

Specifically failing to call the Lambda API in `cdk deploy` with this error:

ServerHostingStack | 11:06:02 a. m. | CREATE_FAILED | AWS::Lambda::Function | SatisfactoryHostingStartServerLambda (SatisfactoryHostingStartServerLambda87DC9D06) Resource handler returned message: "The runtime parameter of nodejs14.x is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs20.x) while creating or updating functions. (Service: Lambda, Status Code: 400, Request ID: 04a35c24-ef0c-40b6-90e6-9502e6739346)" (RequestToken: b854220e-f84f-60b7-b747-71bdb34c4257, HandlerErrorCode: InvalidRequest)