### PR TITLE
Added support for Duck DNS config and service to run on startup

### DIFF
--- a/server-hosting/config.sample.ts
+++ b/server-hosting/config.sample.ts
@@ -29,5 +29,9 @@ export const Config = {
      // If vpc is not given specify subnet for default vpc
      subnetId: '',
      // Needed if subnetId is specified (i.e. us-west-2a)
-     availabilityZone: ''
+     availabilityZone: '',
+     // If using Duck DNS specify these
+     // Domain should not include duckdns.org
+     duckDnsToken: '',
+     duckDnsDomain: ''
 };

--- a/server-hosting/scripts/duck-dns.sh
+++ b/server-hosting/scripts/duck-dns.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Configuration
+DOMAIN="your-duckdns-domain"  # Replace with your Duck DNS subdomain
+TOKEN="your-duckdns-token"    # Replace with your Duck DNS token
+
+# Get the instance's public IPs
+IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+IPV6=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv6)
+
+# Update Duck DNS
+# https://www.duckdns.org/update?domains={YOURVALUE}&token={YOURVALUE}[&ip={YOURVALUE}][&ipv6={YOURVALUE}][&verbose=true][&clear=true]
+URL="https://www.duckdns.org/update?domains=$DOMAIN&token=$TOKEN&ip=$IP&ipv6=$IPV6"
+
+RESPONSE=$(curl -s $URL)
+
+# Check if the update was successful
+if [ "$RESPONSE" = "OK" ]; then
+    echo "Duck DNS updated successfully with IP: $IP"
+else
+    echo "Failed to update Duck DNS"
+fi

--- a/server-hosting/scripts/duck-dns.sh
+++ b/server-hosting/scripts/duck-dns.sh
@@ -6,11 +6,10 @@ TOKEN="your-duckdns-token"    # Replace with your Duck DNS token
 
 # Get the instance's public IPs
 IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-IPV6=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv6)
 
 # Update Duck DNS
 # https://www.duckdns.org/update?domains={YOURVALUE}&token={YOURVALUE}[&ip={YOURVALUE}][&ipv6={YOURVALUE}][&verbose=true][&clear=true]
-URL="https://www.duckdns.org/update?domains=$DOMAIN&token=$TOKEN&ip=$IP&ipv6=$IPV6"
+URL="https://www.duckdns.org/update?domains=$DOMAIN&token=$TOKEN&ip=$IP"
 
 RESPONSE=$(curl -s $URL)
 

--- a/server-hosting/scripts/install.sh
+++ b/server-hosting/scripts/install.sh
@@ -38,7 +38,7 @@ After=syslog.target network.target nss-lookup.target network-online.target
 [Service]
 Environment="LD_LIBRARY_PATH=./linux64"
 ExecStartPre=$STEAM_INSTALL_SCRIPT
-ExecStart=/home/ubuntu/.steam/steamapps/common/SatisfactoryDedicatedServer/FactoryServer.sh
+ExecStart=/home/ubuntu/.steam/steamapps/common/SatisfactoryDedicatedServer/FactoryServer.sh -multihome=0.0.0.0
 User=ubuntu
 Group=ubuntu
 StandardOutput=journal
@@ -114,11 +114,10 @@ TOKEN="$DUCK_DNS_TOKEN"
 
 # Get the instance's public IP
 IP=\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
-IPV6=\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv6)
 
 # Update Duck DNS
 # https://www.duckdns.org/update?domains={YOURVALUE}&token={YOURVALUE}[&ip={YOURVALUE}][&ipv6={YOURVALUE}][&verbose=true][&clear=true]
-URL="https://www.duckdns.org/update?domains=\$DOMAIN&token=\$TOKEN&ip=\$IP&ipv6=\$IPV6"
+URL="https://www.duckdns.org/update?domains=\$DOMAIN&token=\$TOKEN&ip=\$IP"
 
 RESPONSE=\$(curl -s \$URL)
 

--- a/server-hosting/scripts/install.sh
+++ b/server-hosting/scripts/install.sh
@@ -5,7 +5,8 @@
 #  2: true|false - whether to use Satisfactory Experimental build (optional, default false)
 S3_SAVE_BUCKET=$1
 USE_EXPERIMENTAL_BUILD=${2-false}
-
+DUCK_DNS_TOKEN=$3
+DUCK_DNS_DOMAIN=$4
 
 # install steamcmd: https://developer.valvesoftware.com/wiki/SteamCMD?__cf_chl_jschl_tk__=pmd_WNQPOiK18.h0rf16RCYrARI2s8_84hUMwT.7N1xHYcs-1635248050-0-gqNtZGzNAiWjcnBszQiR#Linux.2FmacOS)
 add-apt-repository multiverse
@@ -51,7 +52,7 @@ EOF
 systemctl enable satisfactory
 systemctl start satisfactory
 
-# enable auto shutdown: https://github.com/feydan/satisfactory-tools/tree/main/shutdown
+# enable auto shutdown: https://github.com/feydan/satisfactory-tools/tree/main/server-hosting/scripts/auto-shutdown.sh
 cat << 'EOF' > /home/ubuntu/auto-shutdown.sh
 #!/bin/sh
 
@@ -102,6 +103,49 @@ WantedBy=multi-user.target
 EOF
 systemctl enable auto-shutdown
 systemctl start auto-shutdown
+
+# enable duck dns: https://github.com/feydan/satisfactory-tools/tree/main/server-hosting/scripts/duck-dns.sh
+cat << EOF > /home/ubuntu/duck-dns.sh
+#!/bin/sh
+
+# Configuration
+DOMAIN="$DUCK_DNS_DOMAIN"
+TOKEN="$DUCK_DNS_TOKEN"
+
+# Get the instance's public IP
+IP=\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+IPV6=\$(curl -s http://169.254.169.254/latest/meta-data/public-ipv6)
+
+# Update Duck DNS
+# https://www.duckdns.org/update?domains={YOURVALUE}&token={YOURVALUE}[&ip={YOURVALUE}][&ipv6={YOURVALUE}][&verbose=true][&clear=true]
+URL="https://www.duckdns.org/update?domains=\$DOMAIN&token=\$TOKEN&ip=\$IP&ipv6=\$IPV6"
+
+RESPONSE=\$(curl -s \$URL)
+
+# Check if the update was successful
+if [ "\$RESPONSE" = "OK" ]; then
+    echo "Duck DNS updated successfully with IP: \$IP"
+else
+    echo "Failed to update Duck DNS"
+fi
+EOF
+chmod +x /home/ubuntu/duck-dns.sh
+chown ubuntu:ubuntu /home/ubuntu/duck-dns.sh
+
+cat << 'EOF' > /etc/systemd/system/duck-dns.service
+[Unit]
+Description=Update Duck DNS with the current IP on startup
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/ubuntu/duck-dns.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable duck-dns
+systemctl start duck-dns
 
 # automated backups to s3 every 5 minutes
 su - ubuntu -c "crontab -l -e ubuntu | { cat; echo \"*/5 * * * * /usr/local/bin/aws s3 sync /home/ubuntu/.config/Epic/FactoryGame/Saved/SaveGames/server s3://$S3_SAVE_BUCKET\"; } | crontab -"

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -1,12 +1,12 @@
 import { Duration, Stack, StackProps } from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { Config } from './config';
+import * as apigw from 'aws-cdk-lib/aws-apigateway';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda_nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3_assets from 'aws-cdk-lib/aws-s3-assets';
-import * as lambda_nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as apigw from 'aws-cdk-lib/aws-apigateway';
+import { Construct } from 'constructs';
+import { Config } from './config';
 
 export class ServerHostingStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -131,7 +131,7 @@ export class ServerHostingStack extends Stack {
     });
     server.userData.addExecuteFileCommand({
       filePath: localPath,
-      arguments: `${savesBucket.bucketName} ${Config.useExperimentalBuild}`
+      arguments: `${savesBucket.bucketName} ${Config.useExperimentalBuild} ${Config.duckDnsToken} ${Config.duckDnsDomain}`
     });
 
     //////////////////////////////


### PR DESCRIPTION
Duck DNS support now included with minimal config of a token and domain.

Also added `-multihome 0.0.0.0` to the `ExecStart` of the satisfactory service. This has been required since Satisfactory Update 8 to force the server to listen on IPv4 address as it now defaults to IPv6.