### PR TITLE
Modernised the instance type and block device size

### DIFF
--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -67,7 +67,7 @@ export class ServerHostingStack extends Stack {
 
     const server = new ec2.Instance(this, `${prefix}Server`, {
       // 2 vCPU, 8 GB RAM should be enough for most factories
-      instanceType: new ec2.InstanceType("m6a.large"),
+      instanceType: new ec2.InstanceType("m6a.xlarge"),
       // get exact ami from parameter exported by canonical
       // https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507
       machineImage: ec2.MachineImage.fromSsmParameter("/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"),

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -67,7 +67,7 @@ export class ServerHostingStack extends Stack {
 
     const server = new ec2.Instance(this, `${prefix}Server`, {
       // 2 vCPU, 8 GB RAM should be enough for most factories
-      instanceType: new ec2.InstanceType("m5a.large"),
+      instanceType: new ec2.InstanceType("m6a.large"),
       // get exact ami from parameter exported by canonical
       // https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507
       machineImage: ec2.MachineImage.fromSsmParameter("/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"),
@@ -75,7 +75,7 @@ export class ServerHostingStack extends Stack {
       blockDevices: [
         {
           deviceName: "/dev/sda1",
-          volume: ec2.BlockDeviceVolume.ebs(15),
+          volume: ec2.BlockDeviceVolume.ebs(30, {volumeType: ec2.EbsDeviceVolumeType.GP3}),
         }
       ],
       // server needs a public ip to allow connections


### PR DESCRIPTION
Going by the recommended specs here: https://satisfactory.fandom.com/wiki/Dedicated_servers

I have increased the instance type from m5a.large to m6a.xlarge.
This amounts to better CPU speeds and 2 more cores. It is also an increase of 8GiB RAM to 16GiB.
In the past few updates to the Satisfactory Dedicated Server there have been changes to take advantage of concurrency, before it was heavily single CPU bound. The minimum recommended RAM is now 12GiB, with 16GiB recommended for 4 players or large saves.

I have increased the block device to 30GB as minimum for the server is now 25GB.

If the cost increase is too much m6a.large could work and would be $0.004 per hour (at time of writing) more expensive, with good gains in CPU speed. Cost of m6a.xlarge is double ($0.1728) of a m5a.large.