### PR TITLE
Update for v1.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+#
+# Configure line ending normalisation for this repository.
+# See http://schacon.github.io/git/gitattributes.html for more information.
+#
+# Also each developer should configure the old style normalisation on her workstation
+# (see http://timclem.wordpress.com/2012/03/01/mind-the-end-of-your-line/):
+#
+# Windows user should use: git config --global core.autocrlf = true
+# Unix/Linux users should use: git config --global core.autocrlf = input
+
+# Auto detect text files and perform LF normalization
+# Shell scripts require LF
+*.sh    text eol=lf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "server-hosting",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bin": {
     "server-hosting": "server-hosting/server-hosting.js"
   },
@@ -10,16 +10,16 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/node": "10.17.27",
-    "aws-cdk": "2.3.0",
-    "ts-node": "^9.0.0",
-    "typescript": "~3.9.7",
-    "@aws-sdk/client-ec2": "3.45.0",
-    "esbuild": "0.14.10"
+    "@types/node": "^20.5.0",
+    "aws-cdk": "^2.154.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4",
+    "@aws-sdk/client-ec2": "^3.636.0",
+    "esbuild": "^0.23.1"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.3.0",
-    "constructs": "^10.0.0",
-    "source-map-support": "^0.5.16"
+    "aws-cdk-lib": "^2.154.0",
+    "constructs": "^10.3.0",
+    "source-map-support": "^0.5.21"
   }
 }

--- a/server-hosting/scripts/install.sh
+++ b/server-hosting/scripts/install.sh
@@ -37,13 +37,13 @@ After=syslog.target network.target nss-lookup.target network-online.target
 [Service]
 Environment="LD_LIBRARY_PATH=./linux64"
 ExecStartPre=$STEAM_INSTALL_SCRIPT
-ExecStart=/home/ubuntu/.steam/steamapps/common/SatisfactoryDedicatedServer/FactoryServer.sh
+ExecStart=/home/ubuntu/.steam/SteamApps/common/SatisfactoryDedicatedServer/FactoryServer.sh
 User=ubuntu
 Group=ubuntu
 StandardOutput=journal
 Restart=on-failure
 KillSignal=SIGINT
-WorkingDirectory=/home/ubuntu/.steam/steamapps/common/SatisfactoryDedicatedServer
+WorkingDirectory=/home/ubuntu/.steam/SteamApps/common/SatisfactoryDedicatedServer
 
 [Install]
 WantedBy=multi-user.target
@@ -104,4 +104,4 @@ systemctl enable auto-shutdown
 systemctl start auto-shutdown
 
 # automated backups to s3 every 5 minutes
-su - ubuntu -c "crontab -l -e ubuntu | { cat; echo \"*/5 * * * * /usr/local/bin/aws s3 sync /home/ubuntu/.config/Epic/FactoryGame/Saved/SaveGames/server s3://$S3_SAVE_BUCKET\"; } | crontab -"
+su - ubuntu -c "crontab -u ubuntu -l | { cat; echo \"*/5 * * * * /usr/local/bin/aws s3 sync /home/ubuntu/.config/Epic/FactoryGame/Saved/SaveGames/server s3://$S3_SAVE_BUCKET\"; } | crontab -"

--- a/server-hosting/scripts/install.sh
+++ b/server-hosting/scripts/install.sh
@@ -37,7 +37,7 @@ After=syslog.target network.target nss-lookup.target network-online.target
 [Service]
 Environment="LD_LIBRARY_PATH=./linux64"
 ExecStartPre=$STEAM_INSTALL_SCRIPT
-ExecStart=/home/ubuntu/.steam/SteamApps/common/SatisfactoryDedicatedServer/FactoryServer.sh
+ExecStart=/home/ubuntu/.steam/SteamApps/common/SatisfactoryDedicatedServer/FactoryServer.sh -ServerQueryPort=15777 -BeaconPort=15000 -Port=7777 -log -unattended
 User=ubuntu
 Group=ubuntu
 StandardOutput=journal
@@ -51,7 +51,7 @@ EOF
 systemctl enable satisfactory
 systemctl start satisfactory
 
-# enable auto shutdown: https://github.com/feydan/satisfactory-tools/tree/main/shutdown
+# enable auto shutdown: https://github.com/feydan/satisfactory-tools/tree/main/server-hosting/scripts/auto-shutdown.sh
 cat << 'EOF' > /home/ubuntu/auto-shutdown.sh
 #!/bin/sh
 

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -61,9 +61,12 @@ export class ServerHostingStack extends Stack {
       description: "Allow Satisfactory client to connect to server",
     })
 
-    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(7777), "Game port")
-    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(15000), "Beacon port")
-    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(15777), "Query port")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(7777), "Game port UDP")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(15000), "Beacon port UDP")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.udp(15777), "Query port UDP")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(7777), "Game port TCP")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(15000), "Beacon port TCP")
+    securityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(15777), "Query port TCP")
 
     const server = new ec2.Instance(this, `${prefix}Server`, {
       // 2 vCPU, 8 GB RAM should be enough for most factories

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -67,7 +67,7 @@ export class ServerHostingStack extends Stack {
 
     const server = new ec2.Instance(this, `${prefix}Server`, {
       // 2 vCPU, 8 GB RAM should be enough for most factories
-      instanceType: new ec2.InstanceType("m6a.large"),
+      instanceType: new ec2.InstanceType("m6a.xlarge"),
       // get exact ami from parameter exported by canonical
       // https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507
       machineImage: ec2.MachineImage.fromSsmParameter("/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"),

--- a/server-hosting/server-hosting-stack.ts
+++ b/server-hosting/server-hosting-stack.ts
@@ -67,7 +67,7 @@ export class ServerHostingStack extends Stack {
 
     const server = new ec2.Instance(this, `${prefix}Server`, {
       // 2 vCPU, 8 GB RAM should be enough for most factories
-      instanceType: new ec2.InstanceType("m5a.large"),
+      instanceType: new ec2.InstanceType("m6a.large"),
       // get exact ami from parameter exported by canonical
       // https://discourse.ubuntu.com/t/finding-ubuntu-images-with-the-aws-ssm-parameter-store/15507
       machineImage: ec2.MachineImage.fromSsmParameter("/aws/service/canonical/ubuntu/server/20.04/stable/current/amd64/hvm/ebs-gp2/ami-id"),
@@ -75,7 +75,7 @@ export class ServerHostingStack extends Stack {
       blockDevices: [
         {
           deviceName: "/dev/sda1",
-          volume: ec2.BlockDeviceVolume.ebs(15),
+          volume: ec2.BlockDeviceVolume.ebs(30, {volumeType: ec2.EbsDeviceVolumeType.GP3}),
         }
       ],
       // server needs a public ip to allow connections


### PR DESCRIPTION
Includes all changes from:
- #16 
- #18 
- #20 

In addition changes the following to support Satisfactory v1.0:
- Adds TCP ingress for ports 7777, 15777, and 15000
- Updates launch command with port options (no `-multihome`)